### PR TITLE
Black pre-commit files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
In this PR, I aim to introduice the file `.pre-commit-config.yaml`. This file must be used in order to run-commits. For now, there is only `Black` for the code format